### PR TITLE
fix: support Minecraft 1.21.11 and fix sneaking on non-full blocks

### DIFF
--- a/common/src/main/java/za/co/natashadraper/steppy/mixin/SteppyPlayerMixin.java
+++ b/common/src/main/java/za/co/natashadraper/steppy/mixin/SteppyPlayerMixin.java
@@ -1,6 +1,5 @@
 package za.co.natashadraper.steppy.mixin;
 
-import com.mojang.logging.LogUtils;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.MovementType;
 import net.minecraft.entity.attribute.EntityAttribute;
@@ -9,7 +8,6 @@ import net.minecraft.registry.Registries;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Vec3d;
-import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -28,19 +26,27 @@ public abstract class SteppyPlayerMixin {
     private static final Identifier STEP_HEIGHT_ATTRIBUTE_ID = Identifier.ofVanilla("step_height");
     @Unique
     private static final RegistryEntry<EntityAttribute> STEP_HEIGHT_ATTRIBUTE = Registries.ATTRIBUTE.getEntry(STEP_HEIGHT_ATTRIBUTE_ID).get();
+
+    // Captured lazily the first time we are about to modify the step height, so it
+    // reflects the real vanilla base value (0.6). We deliberately do NOT capture this
+    // in a mixin constructor: mixin constructor injection is unreliable and could leave
+    // a final field at 0.0, which would make disableSteppy() set the step height to 0 and
+    // trap the player while sneaking (vanilla's maybeBackOffFromEdge uses step height as
+    // the ledge-detection fall distance, so a 0 step height reads every drop as a cliff).
     @Unique
-    private static final Logger LOGGER = LogUtils.getLogger();
+    private double steppy$defaultStepHeight;
+    @Unique
+    private boolean steppy$defaultStepHeightCaptured = false;
 
     @Unique
-    private final double steppy$defaultStepHeight;
-
-    public SteppyPlayerMixin() {
-        LOGGER.info("[SteppyPlayerMixin] Initializing SteppyPlayerMixin");
+    private void steppy$captureDefaultStepHeight() {
+        if (steppy$defaultStepHeightCaptured) {
+            return;
+        }
         var stepHeightAttribute = steppy$getStepHeightAttribute();
         assert stepHeightAttribute != null;
         this.steppy$defaultStepHeight = stepHeightAttribute.getBaseValue();
-        LOGGER.info("[SteppyPlayerMixin] Storing default step height of {}", steppy$defaultStepHeight);
-        LOGGER.info("[SteppyPlayerMixin] SteppyPlayerMixin initialised");
+        this.steppy$defaultStepHeightCaptured = true;
     }
 
     @Unique
@@ -62,6 +68,11 @@ public abstract class SteppyPlayerMixin {
 
     @Unique
     private void steppy$disableSteppy() {
+        // If we never captured the vanilla default there is nothing meaningful to restore
+        // to, and writing an uninitialised 0.0 would trap the player while sneaking.
+        if (!steppy$defaultStepHeightCaptured) {
+            return;
+        }
         var stepHeightAttribute = steppy$getStepHeightAttribute();
         assert stepHeightAttribute != null;
         stepHeightAttribute.setBaseValue(steppy$defaultStepHeight);
@@ -69,6 +80,7 @@ public abstract class SteppyPlayerMixin {
 
     @Unique
     private void steppy$setSteppyHeight(double stepHeight) {
+        steppy$captureDefaultStepHeight();
         var stepHeightAttribute = steppy$getStepHeightAttribute();
         assert stepHeightAttribute != null;
         stepHeightAttribute.setBaseValue(stepHeight);
@@ -77,10 +89,9 @@ public abstract class SteppyPlayerMixin {
     @Inject(method = "move", at = @At("HEAD"))
     private void steppy(MovementType movementType, Vec3d movement, CallbackInfo ci) {
         if (!steppy$shouldEnableSteppy()) {
-            // Only reset step height once when transitioning from enabled to disabled.
-            // This prevents constantly overriding the step height (e.g. during sneaking),
-            // which would interfere with vanilla's own step height management for
-            // descending from non-full blocks.
+            // Restore the vanilla step height once when transitioning from enabled to
+            // disabled, so vanilla movement (including sneaking off non-full blocks such
+            // as slabs) behaves exactly as it would without the mod.
             if (steppy$active) {
                 steppy$disableSteppy();
                 steppy$active = false;

--- a/common/src/main/java/za/co/natashadraper/steppy/mixin/SteppyPlayerMixin.java
+++ b/common/src/main/java/za/co/natashadraper/steppy/mixin/SteppyPlayerMixin.java
@@ -58,6 +58,9 @@ public abstract class SteppyPlayerMixin {
     }
 
     @Unique
+    private boolean steppy$active = false;
+
+    @Unique
     private void steppy$disableSteppy() {
         var stepHeightAttribute = steppy$getStepHeightAttribute();
         assert stepHeightAttribute != null;
@@ -74,10 +77,18 @@ public abstract class SteppyPlayerMixin {
     @Inject(method = "move", at = @At("HEAD"))
     private void steppy(MovementType movementType, Vec3d movement, CallbackInfo ci) {
         if (!steppy$shouldEnableSteppy()) {
-            steppy$disableSteppy();
+            // Only reset step height once when transitioning from enabled to disabled.
+            // This prevents constantly overriding the step height (e.g. during sneaking),
+            // which would interfere with vanilla's own step height management for
+            // descending from non-full blocks.
+            if (steppy$active) {
+                steppy$disableSteppy();
+                steppy$active = false;
+            }
             return;
         }
         steppy$setSteppyHeight(SteppyConfig.get().stepHeight);
+        steppy$active = true;
     }
 
     @Inject(method = "shouldAutoJump", at = @At(value = "HEAD"), cancellable = true)

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.16",
-    "minecraft": "1.21.5",
+    "minecraft": ">=1.21.5",
     "java": ">=21",
     "cloth-config": ">=18"
   },

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=true
 
 # Mod properties
 
-mod_version = 1.21.11-1.3.1
+mod_version = 1.21.11-1.3.2
 maven_group = za.co.natashadraper.steppy
 archives_name = steppy
 enabled_platforms = fabric,neoforge

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,20 +4,20 @@ org.gradle.parallel=true
 
 # Mod properties
 
-mod_version = 1.21.5-1.3.1
+mod_version = 1.21.11-1.3.1
 maven_group = za.co.natashadraper.steppy
 archives_name = steppy
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 1.21.5
-yarn_mappings = 1.21.5+build.1
+minecraft_version = 1.21.11
+yarn_mappings = 1.21.11+build.2
 
 # Dependencies
-architectury_api_version = 16.1.4
-fabric_loader_version = 0.16.14
-fabric_api_version = 0.124.2+1.21.5
-neoforge_version = 21.5.66-beta
+architectury_api_version = 19.0.1
+fabric_loader_version = 0.18.4
+fabric_api_version = 0.141.3+1.21.11
+neoforge_version = 21.11.151-beta
 yarn_mappings_patch_neoforge_version = 1.21+build.4
 
 cloth_config_version=18.0.145

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -16,14 +16,14 @@ logoFile = "assets/steppy/icon.png"
 [[dependencies.steppy]]
 modId = "neoforge"
 type = "required"
-versionRange = "[21.5,)"
+versionRange = "[21.5,22)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.steppy]]
 modId = "minecraft"
 type = "required"
-versionRange = "[1.21.5,)"
+versionRange = "[1.21.5,1.22)"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
Resolve #8 
- Add steppy$active state tracking to prevent constant step height override during sneaking, which blocked descending from non-full blocks (slabs, etc.)
- Update Minecraft version from 1.21.5 to 1.21.11
- Update dependency versions: Fabric Loader 0.18.4, Fabric API 0.141.3, Architectury 19.0.1, NeoForge 21.11.x, Yarn mappings 1.21.11+build.2
- Widen Minecraft version ranges in fabric.mod.json and neoforge.mods.toml